### PR TITLE
Update "Running An Historical Node Using Docker"

### DIFF
--- a/2024-10-10-running-an-historical-node-using-docker.mdx
+++ b/2024-10-10-running-an-historical-node-using-docker.mdx
@@ -104,10 +104,10 @@ Don't forget to set `ATTO_PUBLIC_URI`, otherwise your node won't be reachable. `
 
 ## Step 4: Verify Your Node
 
-To verify that your node is running correctly, you can check its status by executing:
+To verify that your node is running correctly, you can check its status by executing the following on the same machine:
 
 ```bash
-docker compose exec node curl -f http://localhost:8081/health
+curl -f http://localhost:8081/health
 ```
 
 This command will provide you with information about the node's health status.

--- a/2024-10-10-running-an-historical-node-using-docker.mdx
+++ b/2024-10-10-running-an-historical-node-using-docker.mdx
@@ -99,7 +99,7 @@ This will start both the MySQL service and the Atto node service in detached mod
 The configuration for the node is already provided in the `docker-compose.yml` file under the environment variables section. You should modify the `ATTO_PUBLIC_URI`, `ATTO_DB_NAME`, `ATTO_DB_USER`, `ATTO_DB_PASSWORD`, and other settings to suit your setup.
 
 :::warning
-Don't forget to set `ATTO_PUBLIC_URI`, otherwise your node won't be reachable.
+Don't forget to set `ATTO_PUBLIC_URI`, otherwise your node won't be reachable. `{external-ip}` should be replaced with your actual public IP address, which can be found at [whatismyip.com](https://whatismyipaddress.com/).
 :::
 
 ## Step 4: Verify Your Node


### PR DESCRIPTION
This PR changes the command used to perform a health check, because the previous command did not work since curl is not installed on the node.

This PR also clarifies how ATTO_PUBLIC_URI should be set.

This PR is tiny, so if there's something else I could add, please let me know. For example, I could add instructions for viewing and interpreting the node's log.

atto://ad7z3jdoeqwayzpaiafizb5su6zc2fyvbeg2wq5t3yfj3q5iuprx23z437juk