### PR TITLE
Move truncate to cut off section links

### DIFF
--- a/2026-01-22-how-to-host-a-staking-voter/index.mdx
+++ b/2026-01-22-how-to-host-a-staking-voter/index.mdx
@@ -24,11 +24,9 @@ Thanks to its lightweight design, a voter can be hosted on all but the oldest an
 may have laying around. Nodes hosted on higher-end hardware, however, improve network speed and will receive greater scores and rewards at a
 later stage of the staking system.
 
-This guide explains the process of setting up a voter. Readers that have a fresh, working installation of Linux can skip the next section to
-[Securing the Server](#securing-the-server), while readers who have already set up secure remote login and a user account can skip to
-[Running the Node](#running-the-node).
-
-<!-- truncate -->
+This guide explains the process of setting up a voter. <!-- truncate -->Readers that have a fresh, working installation of Linux can skip
+the next section to [Securing the Server](#securing-the-server), while readers who have already set up secure remote login and a user
+account can skip to [Running the Node](#running-the-node).
 
 ## Obtaining a Private Server
 


### PR DESCRIPTION
The section links in the introduction (e.g. `[Securing the Server](#securing-the-server)`) don't work at [atto.cash/blog](https://atto.cash/blog). This is because those links reference the current page.

This commit moves `<!-- truncate -->` to before the section links. Placing it in the middle of a paragraph like this is okay; I have tested it.